### PR TITLE
Stream command option

### DIFF
--- a/run-mariabackup.sh
+++ b/run-mariabackup.sh
@@ -12,6 +12,7 @@ MYSQL_USER=backup
 MYSQL_HOST=localhost
 MYSQL_PORT=3306
 BACKCMD=mariabackup # Galera Cluster uses mariabackup instead of xtrabackup.
+GZIPCMD=pigz -p8
 BACKDIR=/data/mysql_backup
 FULLBACKUPCYCLE=604800 # Create a new full backup every X seconds
 KEEP=3 # Number of additional backups cycles a backup should kept for.
@@ -130,7 +131,7 @@ then
   mkdir -p $TARGETDIR
 
   # Create incremental Backup
-  $BACKCMD --backup $USEROPTIONS $ARGS --extra-lsndir=$TARGETDIR --incremental-basedir=$INCRBASEDIR --stream=xbstream | gzip > $TARGETDIR/backup.stream.gz
+  $BACKCMD --backup $USEROPTIONS $ARGS --extra-lsndir=$TARGETDIR --incremental-basedir=$INCRBASEDIR --stream=xbstream | $GZIPCMD > $TARGETDIR/backup.stream.gz
 else
   echo 'New full backup'
 
@@ -138,7 +139,7 @@ else
   mkdir -p $TARGETDIR
 
   # Create a new full backup
-  $BACKCMD --backup $USEROPTIONS $ARGS --extra-lsndir=$TARGETDIR --stream=xbstream | gzip > $TARGETDIR/backup.stream.gz
+  $BACKCMD --backup $USEROPTIONS $ARGS --extra-lsndir=$TARGETDIR --stream=xbstream | $GZIPCMD > $TARGETDIR/backup.stream.gz
 fi
 
 MINS=$(($FULLBACKUPCYCLE * ($KEEP + 1 ) / 60))

--- a/run-mariabackup.sh
+++ b/run-mariabackup.sh
@@ -17,6 +17,7 @@ MYSQL_HOST=localhost
 MYSQL_PORT=3306
 BACKCMD=mariabackup # Galera Cluster uses mariabackup instead of xtrabackup.
 GZIPCMD=gzip  # pigz (a parallel implementation of gzip) could be used if available.
+STREAMCMD=xbstream # sometimes named mbstream to avoid clash with Percona command
 BACKDIR=/data/mysql_backup
 FULLBACKUPCYCLE=604800 # Create a new full backup every X seconds
 KEEP=3  # Number of additional backups cycles a backup should be kept for.
@@ -139,7 +140,7 @@ then
   mkdir -p $TARGETDIR
 
   # Create incremental Backup
-  $BACKCMD --backup $USEROPTIONS $ARGS --extra-lsndir=$TARGETDIR --incremental-basedir=$INCRBASEDIR --stream=xbstream | $GZIPCMD > $TARGETDIR/backup.stream.gz
+  $BACKCMD --backup $USEROPTIONS $ARGS --extra-lsndir=$TARGETDIR --incremental-basedir=$INCRBASEDIR --stream=$STREAMCMD | $GZIPCMD > $TARGETDIR/backup.stream.gz
 else
   echo 'New full backup'
 
@@ -147,7 +148,7 @@ else
   mkdir -p $TARGETDIR
 
   # Create a new full backup
-  $BACKCMD --backup $USEROPTIONS $ARGS --extra-lsndir=$TARGETDIR --stream=xbstream | $GZIPCMD > $TARGETDIR/backup.stream.gz
+  $BACKCMD --backup $USEROPTIONS $ARGS --extra-lsndir=$TARGETDIR --stream=$STREAMCMD | $GZIPCMD > $TARGETDIR/backup.stream.gz
 fi
 
 MINS=$(($FULLBACKUPCYCLE * ($KEEP + 1 ) / 60))


### PR DESCRIPTION
`xbstream` was renamed to `mbstream` to avoid clash with Percona command. 

https://jira.mariadb.org/browse/MDEV-15730